### PR TITLE
feat: Security와 jwt 적용

### DIFF
--- a/src/main/java/com/example/outsourcing/common/config/JwtUtil.java
+++ b/src/main/java/com/example/outsourcing/common/config/JwtUtil.java
@@ -1,0 +1,75 @@
+package com.example.outsourcing.common.config;
+
+import com.example.outsourcing.common.enums.UserRole;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.security.auth.message.AuthException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Slf4j(topic = "JwtUtil")
+@Component
+public class JwtUtil {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final long TOKEN_TIME = 30 * 60 * 1000L; // 30분
+
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+    private Key key;
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    public String createToken(Long userId, String username, UserRole userRole) {
+        Date date = new Date();
+
+        return BEARER_PREFIX + Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .claim("username", username)
+                .claim("userRole", userRole)
+                .setExpiration(new Date(date.getTime() + TOKEN_TIME))
+                .setIssuedAt(date)
+                .signWith(key, signatureAlgorithm)
+                .compact();
+    }
+
+    // JWT 반환
+    public String substringToken(String tokenValue) throws AuthException {
+        if (StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)) {
+            return tokenValue.substring(7);
+        }
+        throw new AuthException();
+    }
+
+    // JWT 에서 페이로드 반환
+    public Claims extractClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public String getUsernameFromToken(String token) {
+        return extractClaims(token).get("username", String.class);
+    }
+
+    public UserRole getUserRoleFromToken(String token) {
+        return UserRole.of(extractClaims(token).get("userRole", String.class));
+    }
+
+}

--- a/src/main/java/com/example/outsourcing/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/outsourcing/common/config/SecurityConfig.java
@@ -1,0 +1,52 @@
+package com.example.outsourcing.common.config;
+
+import com.example.outsourcing.common.exception.CustomAccessDeniedHandler;
+import com.example.outsourcing.common.exception.CustomAuthenticationEntryPoint;
+import com.example.outsourcing.common.filter.JwtFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtUtil jwtUtil;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity
+                .cors(Customizer.withDefaults())
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+//                        .requestMatchers("/api/users/register", "/api/users/login").permitAll()
+//                        .anyRequest().authenticated()
+                )
+
+                //JWT 검증 필터 등록
+                .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
+                // 예외 처리 설정
+                .exceptionHandling(configurer ->
+                        configurer
+                                .authenticationEntryPoint(customAuthenticationEntryPoint) // 인증 예외
+                                .accessDeniedHandler(customAccessDeniedHandler) // 인가 예외
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/example/outsourcing/common/dto/ErrorResponseDto.java
+++ b/src/main/java/com/example/outsourcing/common/dto/ErrorResponseDto.java
@@ -1,0 +1,16 @@
+package com.example.outsourcing.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponseDto {
+
+    private final boolean success;
+    private final String message;
+    private final String data;
+    private final String errorCode;
+    private final String timestamp;
+
+}

--- a/src/main/java/com/example/outsourcing/common/enums/UserRole.java
+++ b/src/main/java/com/example/outsourcing/common/enums/UserRole.java
@@ -1,0 +1,14 @@
+package com.example.outsourcing.common.enums;
+
+import java.util.Arrays;
+
+public enum UserRole {
+    ADMIN, USER;
+
+    public static UserRole of(String role) {
+        return Arrays.stream(UserRole.values())
+                .filter(r -> r.name().equalsIgnoreCase(role))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 UerRole"));
+    }
+}

--- a/src/main/java/com/example/outsourcing/common/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/outsourcing/common/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,45 @@
+package com.example.outsourcing.common.exception;
+
+import com.example.outsourcing.common.dto.ErrorResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        HttpStatus status = HttpStatus.FORBIDDEN;
+
+        ErrorResponseDto errorResponseDto = new ErrorResponseDto(
+                false,
+                "AccessDenied Uri : " + accessDeniedException.getMessage(),
+                null,
+                status.getReasonPhrase(),
+                LocalDateTime.now().toString()
+        );
+        String responseBody = objectMapper.writeValueAsString(errorResponseDto);
+
+        log.error("FORBIDDEN: AccessDenied - Uri : {}", request.getRequestURI());
+
+        response.setStatus(status.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(responseBody);
+    }
+}

--- a/src/main/java/com/example/outsourcing/common/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/outsourcing/common/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,45 @@
+package com.example.outsourcing.common.exception;
+
+import com.example.outsourcing.common.dto.ErrorResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        HttpStatus status = HttpStatus.UNAUTHORIZED;
+
+        ErrorResponseDto errorResponseDto = new ErrorResponseDto(
+                false,
+                "인증되지 않은 URL 요청입니다. : " + authException.getMessage(),
+                null,
+                status.getReasonPhrase(),
+                LocalDateTime.now().toString()
+        );
+        String responseBody = objectMapper.writeValueAsString(errorResponseDto);
+
+        log.error("UNAUTHORIZED: Not Authenticated Request - Uri : {}", request.getRequestURI());
+
+        response.setStatus(status.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(responseBody);
+    }
+}

--- a/src/main/java/com/example/outsourcing/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/outsourcing/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,31 @@
+package com.example.outsourcing.common.exception;
+
+import com.example.outsourcing.common.dto.ErrorResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponseDto> handleIllegalArgumentException(IllegalArgumentException ex) {
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        return getErrorResponse(status, ex.getMessage());
+    }
+
+    public ResponseEntity<ErrorResponseDto> getErrorResponse(HttpStatus status, String message) {
+        ErrorResponseDto errorResponseDto = new ErrorResponseDto(
+                false,
+                message + " : " + status.getReasonPhrase(),
+                null,
+                status.getReasonPhrase(),
+                LocalDateTime.now().toString()
+        );
+        return new ResponseEntity<>(errorResponseDto, status);
+    }
+
+}

--- a/src/main/java/com/example/outsourcing/common/filter/JwtFilter.java
+++ b/src/main/java/com/example/outsourcing/common/filter/JwtFilter.java
@@ -1,0 +1,92 @@
+package com.example.outsourcing.common.filter;
+
+import com.example.outsourcing.common.config.JwtUtil;
+import com.example.outsourcing.common.enums.UserRole;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.security.auth.message.AuthException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j(topic = "JwtFilter")
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain chain
+    ) throws ServletException, IOException {
+
+        String bearerJwt = request.getHeader(AUTHORIZATION_HEADER);
+        if (bearerJwt == null) {
+            // 인증이 필요없으면 다음으로 넘김
+            chain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            String jwt = jwtUtil.substringToken(bearerJwt);
+
+            // JWT 유효성 검사와 claims 추출
+            if (handleInvalidClaims(jwt, response)) return;
+
+            setAuthentication(jwt);
+
+            chain.doFilter(request, response);
+        } catch (AuthException e) {
+            log.error("Not Found Token, JWT 토큰을 찾지 못했습니다.", e);
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "JWT 토큰을 찾지 못했습니다.");
+        } catch (SecurityException | MalformedJwtException e) {
+            log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.", e);
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않는 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token, 만료된 JWT token 입니다.", e);
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.", e);
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "지원되지 않는 JWT 토큰입니다.");
+        } catch (Exception e) {
+            log.error("Invalid JWT token, 유효하지 않는 JWT 토큰 입니다.", e);
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "유효하지 않는 JWT 토큰입니다.");
+        }
+    }
+
+    private boolean handleInvalidClaims(String jwt, HttpServletResponse response) throws IOException {
+        Claims claims = jwtUtil.extractClaims(jwt);
+        if (claims == null) {
+            log.error("잘못된 JWT 토큰입니다.");
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "잘못된 JWT 토큰입니다.");
+            return true;
+        }
+        return false;
+    }
+
+    private void setAuthentication(String jwt) {
+        String username = jwtUtil.getUsernameFromToken(jwt);
+        UserRole userRole = jwtUtil.getUserRoleFromToken(jwt);
+        User user = new User(username, "", List.of(new SimpleGrantedAuthority("ROLE_" + userRole.name())));
+
+        // SecurityContext에 인증 토큰 저장
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities()));
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,6 @@ spring:
   profiles:
     active: local
 
-#jwt:
-#  secret:
-#    key: ${SECRET_KEY}
+jwt:
+  secret:
+    key: ${SECRET_KEY}


### PR DESCRIPTION
UserRole 생성
- common/enums/UserRole.java
- ADMIN, USER

에러 응답 형식 정의
- common/dto/ErrorResponseDto.java

현재 Security는 모든 api 요청을 인증없이 허용함
- 실행전 SECRET_KEY 설정 필수
- 인증, 인가 예외 처리 진행함
- security에서 제공하는 User 객체를 사용하여 SecurityContext에 인증 토큰 저장함