### PR TITLE
공통 response 구현 및 UserRole 예외 문구 오타 변경 

### DIFF
--- a/src/main/java/com/example/outsourcing/common/dto/ErrorResponseDto.java
+++ b/src/main/java/com/example/outsourcing/common/dto/ErrorResponseDto.java
@@ -1,16 +1,16 @@
 package com.example.outsourcing.common.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
-public class ErrorResponseDto {
+public class ErrorResponseDto extends ResponseDto<Void> {
 
-    private final boolean success;
-    private final String message;
-    private final String data;
     private final String errorCode;
-    private final String timestamp;
+
+    public ErrorResponseDto(String message, String errorCode) {
+        super(message, null);
+        this.success = false;
+        this.errorCode = errorCode;
+    }
 
 }

--- a/src/main/java/com/example/outsourcing/common/dto/ResponseDto.java
+++ b/src/main/java/com/example/outsourcing/common/dto/ResponseDto.java
@@ -1,0 +1,24 @@
+package com.example.outsourcing.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@JsonPropertyOrder({"success", "message", "data", "errorCode", "timestamp"})
+public class ResponseDto<T> {
+
+    boolean success;
+    private final String message;
+    private final T data;
+    private final String timestamp;
+
+    public ResponseDto(String message, T data) {
+        this.success = true;
+        this.message = message;
+        this.data = data;
+        this.timestamp = LocalDateTime.now().toString();
+    }
+
+}

--- a/src/main/java/com/example/outsourcing/common/enums/UserRole.java
+++ b/src/main/java/com/example/outsourcing/common/enums/UserRole.java
@@ -9,6 +9,6 @@ public enum UserRole {
         return Arrays.stream(UserRole.values())
                 .filter(r -> r.name().equalsIgnoreCase(role))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 UerRole"));
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 UserRole"));
     }
 }

--- a/src/main/java/com/example/outsourcing/common/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/outsourcing/common/exception/CustomAccessDeniedHandler.java
@@ -13,7 +13,6 @@ import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
 
 @Slf4j
 @Component
@@ -27,11 +26,8 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
         HttpStatus status = HttpStatus.FORBIDDEN;
 
         ErrorResponseDto errorResponseDto = new ErrorResponseDto(
-                false,
                 "AccessDenied Uri : " + accessDeniedException.getMessage(),
-                null,
-                status.getReasonPhrase(),
-                LocalDateTime.now().toString()
+                status.getReasonPhrase()
         );
         String responseBody = objectMapper.writeValueAsString(errorResponseDto);
 

--- a/src/main/java/com/example/outsourcing/common/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/outsourcing/common/exception/CustomAuthenticationEntryPoint.java
@@ -13,7 +13,6 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
 
 @Slf4j
 @Component
@@ -27,11 +26,8 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         HttpStatus status = HttpStatus.UNAUTHORIZED;
 
         ErrorResponseDto errorResponseDto = new ErrorResponseDto(
-                false,
                 "인증되지 않은 URL 요청입니다. : " + authException.getMessage(),
-                null,
-                status.getReasonPhrase(),
-                LocalDateTime.now().toString()
+                status.getReasonPhrase()
         );
         String responseBody = objectMapper.writeValueAsString(errorResponseDto);
 

--- a/src/main/java/com/example/outsourcing/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/outsourcing/common/exception/GlobalExceptionHandler.java
@@ -6,7 +6,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.time.LocalDateTime;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -19,11 +18,8 @@ public class GlobalExceptionHandler {
 
     public ResponseEntity<ErrorResponseDto> getErrorResponse(HttpStatus status, String message) {
         ErrorResponseDto errorResponseDto = new ErrorResponseDto(
-                false,
-                message + " : " + status.getReasonPhrase(),
-                null,
-                status.getReasonPhrase(),
-                LocalDateTime.now().toString()
+                message,
+                status.getReasonPhrase()
         );
         return new ResponseEntity<>(errorResponseDto, status);
     }


### PR DESCRIPTION
ResponseDto : 성공 응답
- success, message, data, timestamp 필드 존재
- success는 true
- message와 data를 입력받음
- data는 제네릭으로 뭐든 들어갈 수 있음
ex) new ResponseDto<>("회원가입이 완료되었습니다.", new UserSignupResponseDto(savedUser));

ErrorResponseDto : 실패 응답
- ErrorResponseDto가 ResponseDto를 상속받는 것으로 변경
- success는 false, data는 null
- errorCode 필드 추가

UserRole 예외 문구 오타 변경 : UerRole -> UserRole