### PR TITLE
fix: security의 User 대신 새로운 인증객체 AuthUser로 변경

### DIFF
--- a/src/main/java/com/example/outsourcing/common/config/JwtUtil.java
+++ b/src/main/java/com/example/outsourcing/common/config/JwtUtil.java
@@ -64,6 +64,10 @@ public class JwtUtil {
                 .getBody();
     }
 
+    public Long getUserIdFromToken(String token) {
+        return Long.parseLong(extractClaims(token).getSubject());
+    }
+
     public String getUsernameFromToken(String token) {
         return extractClaims(token).get("username", String.class);
     }

--- a/src/main/java/com/example/outsourcing/common/entity/AuthUser.java
+++ b/src/main/java/com/example/outsourcing/common/entity/AuthUser.java
@@ -1,0 +1,19 @@
+package com.example.outsourcing.common.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class AuthUser implements UserDetails {
+
+    private final Long id;
+    private final String username;
+    private final String password;
+    private final List<SimpleGrantedAuthority> authorities;
+
+}

--- a/src/main/java/com/example/outsourcing/common/filter/JwtFilter.java
+++ b/src/main/java/com/example/outsourcing/common/filter/JwtFilter.java
@@ -1,6 +1,7 @@
 package com.example.outsourcing.common.filter;
 
 import com.example.outsourcing.common.config.JwtUtil;
+import com.example.outsourcing.common.entity.AuthUser;
 import com.example.outsourcing.common.enums.UserRole;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -17,7 +18,6 @@ import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -80,13 +80,14 @@ public class JwtFilter extends OncePerRequestFilter {
     }
 
     private void setAuthentication(String jwt) {
+        Long id = jwtUtil.getUserIdFromToken(jwt);
         String username = jwtUtil.getUsernameFromToken(jwt);
         UserRole userRole = jwtUtil.getUserRoleFromToken(jwt);
-        User user = new User(username, "", List.of(new SimpleGrantedAuthority("ROLE_" + userRole.name())));
+        AuthUser authUser = new AuthUser(id, username, "", List.of(new SimpleGrantedAuthority("ROLE_" + userRole.name())));
 
         // SecurityContext에 인증 토큰 저장
         SecurityContextHolder.getContext()
-                .setAuthentication(new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities()));
+                .setAuthentication(new UsernamePasswordAuthenticationToken(authUser, null, authUser.getAuthorities()));
     }
 
 }


### PR DESCRIPTION
문제점
- 기존에 security의 User는 엔티티의 User랑 충돌되는 경우가 있어서, 여러모로 불편함
- security의 User에 id값이 존재하지 않아 필요값을 가져오기 힘듦

해결
UserDetails을 구현한 인증객체 AuthUser를 생성함
- id, username, password, authorities의 필드를 가짐

@AuthenticationPrincipal AuthUser authUser 로 사용하면 됨