### PR TITLE
Fix/connect front input

### DIFF
--- a/src/main/java/com/example/outsourcing/common/dto/ErrorResponseDto.java
+++ b/src/main/java/com/example/outsourcing/common/dto/ErrorResponseDto.java
@@ -10,13 +10,13 @@ public class ErrorResponseDto extends ResponseDto<Void> {
 
     private String errorCode;
 
-    public ErrorResponseDto(Object message, String errorCode) {
+    public ErrorResponseDto(String message, String errorCode) {
         super(message, null);
         this.success = false;
         this.errorCode = errorCode;
     }
 
-    public ErrorResponseDto(Object message, ExceptionCode errorCode) {
+    public ErrorResponseDto(String message, ExceptionCode errorCode) {
         super(message, null);
         this.success = false;
         this.errorCode = errorCode.toString();

--- a/src/main/java/com/example/outsourcing/common/dto/ResponseDto.java
+++ b/src/main/java/com/example/outsourcing/common/dto/ResponseDto.java
@@ -13,11 +13,11 @@ import java.time.format.DateTimeFormatter;
 public class ResponseDto<T> {
 
     boolean success;
-    private Object message;
+    private String message;
     private T data;
     private String timestamp;
 
-    public ResponseDto(Object message, T data) {
+    public ResponseDto(String message, T data) {
         this.success = true;
         this.message = message;
         this.data = data;

--- a/src/main/java/com/example/outsourcing/common/exception/exceptions/ExceptionCode.java
+++ b/src/main/java/com/example/outsourcing/common/exception/exceptions/ExceptionCode.java
@@ -11,13 +11,13 @@ public enum ExceptionCode {
     COMMENT_BAD_REQUEST(HttpStatus.BAD_REQUEST, "내용을 입력해야합니다"),
     COMMENT_UPDATED_BAD_REQUEST(HttpStatus.BAD_REQUEST, "기존 내용과 동일한 내용입니다"),
     COMMENT_AUTHOR_MISMATCH(HttpStatus.BAD_REQUEST, "작성자가 아닙니다"),
+    WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 틀렸습니다"),
 
     UNSUPPORTED_JWT_TOKENS(HttpStatus.BAD_REQUEST, "지원되지 않는 JWT 토큰 입니다."),
     INVALID_JWT_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않는 JWT 토큰입니다."),
 
     // 401
-    WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 틀렸습니다"),
-    UNAUTHORIZED_API_REQUEST(HttpStatus.UNAUTHORIZED, "인증되지 않은 URL 요청입니다."),
+    UNAUTHORIZED_API_REQUEST(HttpStatus.UNAUTHORIZED, "인증이 필요합니다"),
     INVALID_JWT_SIGNATURE(HttpStatus.UNAUTHORIZED, "유효하지 않는 JWT 서명입니다."),
     EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
 

--- a/src/main/java/com/example/outsourcing/user/dto/request/UserSignupRequestDto.java
+++ b/src/main/java/com/example/outsourcing/user/dto/request/UserSignupRequestDto.java
@@ -9,6 +9,10 @@ import lombok.Getter;
 @Getter
 public class UserSignupRequestDto {
 
+    @Size(min = 2, max = 50, message = "이름은 2-50자 사이여야 합니다")
+    @NotBlank(message = "이름은 필수입니다")
+    private final String name;
+
     @Pattern(regexp = "^[a-zA-Z0-9]{4,20}$",
             message = "사용자명은 4-20자의 영문/숫자만 허용됩니다")
     @NotBlank(message = "사용자명은 필수입니다")
@@ -22,10 +26,6 @@ public class UserSignupRequestDto {
             message = "비밀번호는 8자 이상의 영문/숫자/특수문자 조합이어야 합니다")
     @NotBlank(message = "비밀번호는 필수입니다")
     private final String password;
-
-    @Size(min = 2, max = 50, message = "이름은 2-50자 사이여야 합니다")
-    @NotBlank(message = "이름은 필수입니다")
-    private final String name;
 
     public UserSignupRequestDto(String username, String email, String password, String name) {
         this.username = username;


### PR DESCRIPTION
1. 비밀번호가 틀릴 시, BAD_REQUEST 반환으로 변경
프론트에서 요구하는 상태코드는 BAD_REQUEST임
- BAD_REQUEST가 아니면 의도하지 않은 페이지로 이동하게 됨


2. valid 예외처리시 맨 위의 하나만 메시지 반환
문제
- 검증 실패한 메시지를 모두 모아서 리스트로 반환함
- Object 시 프론트엔드에서 인식 못하고 오류 발생

해결
- Dto의 message를 String으로 변경
- response dto의 순서에 맞춰, 최상단의 에러 메시지만 출력되도록 변경
- UserSignupRequestDto 순서 변경

protected -> public로 통일